### PR TITLE
Two minor but crucial fixes for recovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,3 +14,12 @@ Due to the earliness of the operation, the rootfs and boot partitions are manual
 After the recovery, they are restored to the previous state.
 
 To fetch the log from a recovery, execute after bootup: `sudo systemctl status kano-os-recovery -b`.
+
+## Querying if system APT is stable
+
+Simply running `sudo kano-os-recovery --info` will display any broken packages, and return exit code 0 if recovery is needed.
+
+## Testing
+
+Additionally, a simulation option is provided for testing purposes by passing the `--test` parameter,
+which can be set in the systemd service file. The recovery will delay the bootup for 30 seconds.

--- a/bin/kano-os-recovery
+++ b/bin/kano-os-recovery
@@ -7,15 +7,38 @@
 #
 # Repairs a broken system due to APT being interrupted during a kano-updater.
 #
+# Syntax: kano-os-recovery < --info | --recovery | --test >
+#
+# Errorlevel is set to 0 if recovery is needed or has been performed.
+# 1 means system is stable.
+#
 
-function is_apt_broken()
+# Operation mode - if absent, assume information mode
+mode=$1
+
+# Delay in seconds for test mode
+test_sleep=30
+
+if [ `id -u` != 0 ]; then
+    echo "You need to be root"
+    exit 1
+fi
+
+function is_apt_stable()
 {
+    # Query if system has any packages in a broken state.
+    # Return code 0 means system is broken, 1 means stable.
     dpkg-query -W -f='${db:Status-Abbrev} ${binary:Package}\n' | grep -E ^.[^nci]
 }
 
 # Does APT report that any packages are in an unstable status?
-is_apt_broken
-if [ $? == 0 ]; then
+is_apt_stable
+system_stable=$?
+echo "System Stable? $system_stable"
+
+if [ $system_stable != 1 ] && [ "$mode" == "--recovery" ]; then
+
+    echo "Recovery is starting now..."
 
     # mount file systems read-write (rootfs and boot are needed by dpkg)
     /bin/mount /dev/mmcblk0p1 /boot
@@ -27,4 +50,13 @@ if [ $? == 0 ]; then
     # restore mount points as they were right before the fix
     /bin/umount /boot
     /bin/mount -o remount,ro /dev/mmcblk0p2 /
+
+    exit 0
 fi
+
+if [ "$mode" == "--test" ]; then
+    echo "Recovery is in test mode - sleeping for $test_sleep secs"
+    /bin/sleep $test_sleep
+fi
+
+exit $system_stable

--- a/bin/kano-os-recovery
+++ b/bin/kano-os-recovery
@@ -15,7 +15,7 @@ function is_apt_broken()
 
 # Does APT report that any packages are in an unstable status?
 is_apt_broken
-if [ $? != 0 ]; then
+if [ $? == 0 ]; then
 
     # mount file systems read-write (rootfs and boot are needed by dpkg)
     /bin/mount /dev/mmcblk0p1 /boot

--- a/systemd/kano-os-recovery.service
+++ b/systemd/kano-os-recovery.service
@@ -11,6 +11,7 @@
 Description=Kano OS Recovery
 DefaultDependencies=no
 After=kano-os-loader.service
+Before=systemd-remount-fs.service
 
 [Service]
 StandardOutput=journal

--- a/systemd/kano-os-recovery.service
+++ b/systemd/kano-os-recovery.service
@@ -17,7 +17,7 @@ Before=systemd-remount-fs.service
 StandardOutput=journal
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/kano-os-recovery
+ExecStart=/usr/bin/kano-os-recovery --recovery
 TimeoutSec=0
 
 [Install]


### PR DESCRIPTION
This PR addresses 2 fixes that I have reproduced on the Kit:

 * Reverse the logic condition to decide if systems needs recovery
 * Stall the boot process until this service terminates recovery
