### PR TITLE
Add additional command to fix broken packages

### DIFF
--- a/bin/kano-os-recovery
+++ b/bin/kano-os-recovery
@@ -47,6 +47,9 @@ if [ $system_stable != 1 ] && [ "$mode" == "--recovery" ]; then
     # tell apt to fix the database by unfolding half-installed/configured packages
     /usr/bin/dpkg --configure -a
 
+    # try to fix broken packages even if previous command was successful
+    /usr/bin/apt-get install --fix-broken --yes
+
     # restore mount points as they were right before the fix
     /bin/umount /boot
     /bin/mount -o remount,ro /dev/mmcblk0p2 /


### PR DESCRIPTION
Initially, the command `apt-get install --fix-broken` was removed from the list of things to do, as it seemed unnecessary.

However, I have reached the system in a point where either `kano-os-recovery` nor `kano-updater` would be able to proceed further, by breaking the upgrade 3 consecutive times, leaving the system unable to even continue wiht the upgrade - error message "You have held broken packages".

Running the above command unblocked the situation and kano-updater terminated successfully this time. So this PR addresses this edge case.
