### PR TITLE
Fixing return code to systemd

### DIFF
--- a/systemd/kano-os-recovery.service
+++ b/systemd/kano-os-recovery.service
@@ -17,7 +17,7 @@ Before=systemd-remount-fs.service
 StandardOutput=journal
 Type=oneshot
 RemainAfterExit=yes
-ExecStart=/usr/bin/kano-os-recovery --recovery
+ExecStart=-/usr/bin/kano-os-recovery --recovery
 TimeoutSec=0
 
 [Install]


### PR DESCRIPTION
The tool that performs the OS recovery returns an errorlevel indication to say weather the system needed a repair or not. This was confusing systemd and displaying a console error when the system was healthy.

Fixing by telling systemd to ignore the return code - We do have a journal log, and a query option too - `kano-os-recovery --info`
